### PR TITLE
Improve aware generators to support Class Sourced Args

### DIFF
--- a/src/sqlacodegen/generators.py
+++ b/src/sqlacodegen/generators.py
@@ -44,7 +44,6 @@ from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.engine import Connection, Engine
 from sqlalchemy.exc import CompileError
 from sqlalchemy.sql.elements import TextClause
-from sqlalchemy import create_engine, text
 
 from .models import (
     ColumnAttribute,
@@ -334,9 +333,7 @@ class TablesGenerator(CodeGenerator):
         self.collect_imports(models)
 
         # Generate names for models
-        global_names = {
-            name for namespace in self.imports.values() for name in namespace
-        }
+        global_names = {name for namespace in self.imports.values() for name in namespace}
         for model in models:
             self.generate_model_name(model, global_names)
             global_names.add(model.name)
@@ -580,9 +577,7 @@ class TablesGenerator(CodeGenerator):
         args: list[str] = []
         kwargs: dict[str, Any] = {}
         if isinstance(constraint, ForeignKey):
-            remote_column = (
-                f"{constraint.column.table.fullname}.{constraint.column.name}"
-            )
+            remote_column = f"{constraint.column.table.fullname}.{constraint.column.name}"
             add_fk_options(remote_column)
         elif isinstance(constraint, ForeignKeyConstraint):
             local_columns = get_column_names(constraint)
@@ -606,9 +601,7 @@ class TablesGenerator(CodeGenerator):
         return render_callable(constraint.__class__.__name__, *args, kwargs=kwargs)
 
     def render_python_enum(self, name: str, values: list[str]) -> str:
-        enum_members = "\n    ".join(
-            [f"{value.upper()} = '{value}'" for value in values]
-        )
+        enum_members = "\n    ".join([f"{value.upper()} = '{value}'" for value in values])
         return f"class {name}(enum.Enum):\n    {enum_members}\n"
 
     def should_ignore_table(self, table: Table) -> bool:
@@ -672,9 +665,7 @@ class TablesGenerator(CodeGenerator):
                             table.constraints.remove(constraint)
                             if not isinstance(table.c[colname].type, Enum):
                                 options = _re_enum_item.findall(items)
-                                table.c[colname].type = Enum(
-                                    *options, native_enum=False
-                                )
+                                table.c[colname].type = Enum(*options, native_enum=False)
 
                             continue
 
@@ -858,9 +849,7 @@ class DeclarativeGenerator(TablesGenerator):
 
         # Rename models and their attributes that conflict with imports or other
         # attributes
-        global_names = {
-            name for namespace in self.imports.values() for name in namespace
-        }
+        global_names = {name for namespace in self.imports.values() for name in namespace}
         for model in models_by_table_name.values():
             self.generate_model_name(model, global_names)
             global_names.add(model.name)
@@ -924,8 +913,7 @@ class DeclarativeGenerator(TablesGenerator):
                 )
                 if len(common_fk_constraints) > 1:
                     relationship.foreign_keys = [
-                        source.get_column_attribute(key)
-                        for key in constraint.column_keys
+                        source.get_column_attribute(key) for key in constraint.column_keys
                     ]
 
                 # Generate the opposite end of the relationship in the target class
@@ -1113,9 +1101,7 @@ class DeclarativeGenerator(TablesGenerator):
                     if inflected_name:
                         preferred_name = inflected_name
 
-        relationship.name = self.find_free_name(
-            preferred_name, global_names, local_names
-        )
+        relationship.name = self.find_free_name(preferred_name, global_names, local_names)
 
     def render_models(self, models: list[Model]) -> str:
         rendered: list[str] = []
@@ -1149,8 +1135,7 @@ class DeclarativeGenerator(TablesGenerator):
 
         # Render relationship attributes
         rendered_relationship_attributes: list[str] = [
-            self.render_relationship(relationship)
-            for relationship in model.relationships
+            self.render_relationship(relationship) for relationship in model.relationships
         ]
 
         if rendered_relationship_attributes:
@@ -1371,10 +1356,7 @@ class DataclassGenerator(DeclarativeGenerator):
                 LiteralImport("sqlalchemy.orm", "MappedAsDataclass"),
             ],
             declarations=[
-                (
-                    f"class {self.base_class_name}(MappedAsDataclass, "
-                    "DeclarativeBase):"
-                ),
+                f"class {self.base_class_name}(MappedAsDataclass, DeclarativeBase):",
                 f"{self.indentation}pass",
             ],
             metadata_ref=f"{self.base_class_name}.metadata",
@@ -1468,9 +1450,7 @@ class SQLModelGenerator(DeclarativeGenerator):
 
         # Rename models and their attributes that conflict with imports or other
         # attributes
-        global_names = {
-            name for namespace in self.imports.values() for name in namespace
-        }
+        global_names = {name for namespace in self.imports.values() for name in namespace}
         for model in models_by_table_name.values():
             self.generate_model_name(model, global_names)
             global_names.add(model.name)
@@ -1667,9 +1647,7 @@ class AwareGenerator(SQLModelGenerator):
         for model in models:
             if isinstance(model, ModelClass):
                 functions = class_functions.get(model.table.name, [])
-                rendered.append(
-                    self.render_class_with_supabase_methods(model, functions)
-                )
+                rendered.append(self.render_class_with_supabase_methods(model, functions))
             else:
                 rendered.append(f"{model.name} = {self.render_table(model.table)}")
 
@@ -1724,9 +1702,11 @@ class AwareGenerator(SQLModelGenerator):
         docstring = self.render_docstring(func_meta, return_python_type)
 
         rpc_args = [
-            f'"{arg.name}": {"self." + arg.class_attribute if arg.class_sourced else arg.name}'
+            f'"{arg.name}": '
+            f'{"self." + arg.class_attribute if arg.class_sourced else arg.name}'
             for arg in func_meta.arguments
         ]
+
         rpc_args_str = ",\n".join(f"{self.indentation * 4}{arg}" for arg in rpc_args)
 
         method = f"""
@@ -1771,7 +1751,7 @@ class AwareGenerator(SQLModelGenerator):
 class ArgumentInfo:
     name: str
     type: str
-    default: any = None
+    default: Any = None
     class_sourced: bool = False
     class_attribute: str = ""
 
@@ -1833,17 +1813,15 @@ class FunctionGenerator:
                     class_functions[function_table].append(func_metadata)
             return class_functions
 
-    def parse_comments(self, comment: str) -> tuple[str, dict[str, any]]:
+    def parse_comments(self, comment: str) -> tuple[str, dict[str, Any]]:
         if not comment:
             return "", {}
 
-        docstring_match = re.search(
-            r"DOCSTRING:\s*(.*?)\nMETADATA:", comment, re.DOTALL
-        )
+        docstring_match = re.search(r"DOCSTRING:\s*(.*?)\nMETADATA:", comment, re.DOTALL)
         metadata_match = re.search(r"METADATA:(.*)", comment, re.DOTALL)
 
         docstring = docstring_match.group(1).strip() if docstring_match else ""
-        metadata: dict[str, any] = {}
+        metadata: dict[str, Any] = {}
 
         if metadata_match:
             metadata_content = metadata_match.group(1).strip()


### PR DESCRIPTION
- New "Class Sourced Args" metedata field that allows to specify arguments that should be obtained from the class member list.
- Comes with Function Name to adjust the name optionally
- Renamed the class name to function table for consistency.


```sql
/* Update pretty string */
CREATE OR REPLACE FUNCTION update_tool_call_pretty_string(p_tool_call_id uuid, p_pretty_string text)
    RETURNS void
    AS $$
BEGIN
    -- Update the pretty string of the tool call.
    UPDATE
        tool_call
    SET
        pretty_string = p_pretty_string
    WHERE
        id = p_tool_call_id;
END;
$$
LANGUAGE plpgsql;

COMMENT ON FUNCTION update_tool_call_pretty_string(uuid, text) IS $$
DOCSTRING:
    Updates the pretty string of a tool call.
    Parameters:
        p_tool_call_id: The UUID of the tool call.
        p_pretty_string: The pretty string to update.
METADATA:
    Function Table: tool_call
    Function Name: set_pretty_string
    Class Sourced Args: p_tool_call_id=id
$$;

```

Generated python class is:

```python
class PgToolCall(AwareSQLModel, table=True):
    __tablename__ = 'tool_call'
    __table_args__ = (
        ForeignKeyConstraint(['message_assistant_id'], ['message_assistant.id'], ondelete='CASCADE', name='tool_call_message_assistant_id_fkey'),
        PrimaryKeyConstraint('id', name='tool_call_pkey'),
        Index('tool_call_message_id_idx', 'message_assistant_id')
    )

    id: str = Field(sa_column=Column('id', Uuid, primary_key=True, server_default=text('gen_random_uuid()')))
    message_assistant_id: str = Field(sa_column=Column('message_assistant_id', Uuid, nullable=False))
    created_at: datetime = Field(sa_column=Column('created_at', DateTime(True), nullable=False, server_default=text('CURRENT_TIMESTAMP')))
    provider_tool_call_id: str = Field(sa_column=Column('provider_tool_call_id', Text, nullable=False))
    tool_name: str = Field(sa_column=Column('tool_name', Text, nullable=False))
    arguments: str = Field(sa_column=Column('arguments', Text, nullable=False))
    pretty_string: Optional[str] = Field(default=None, sa_column=Column('pretty_string', Text))

    message_assistant: Optional['PgMessageAssistant'] = Relationship(back_populates='tool_call')
    tool_response: Optional['PgToolResponse'] = Relationship(sa_relationship_kwargs={'uselist': False}, back_populates='tool_call')
    request: List['PgRequest'] = Relationship(back_populates='tool_call')

    def create_tool_response(self, p_tool_call_id: str, p_tool_name: str, p_provider_tool_call_id: str, p_content: str, p_is_error: bool) -> str:
        """
        Creates a new tool response, used to saved the AI model tool response into a common representation.
        Parameters:
            p_tool_call_id: The tool call id.
            p_tool_name: The name of the tool.
            p_provider_tool_call_id: The model provider tool call id.
            p_content: The content of the tool response.
            p_is_error: A flag to indicate if the response is an error.
        Returns:
            The ID of the new tool response.

        Returns:
            str
        """
        return self.get_supabase_client().rpc(
            "create_tool_response",
            {
                "p_tool_call_id": p_tool_call_id,
                "p_tool_name": p_tool_name,
                "p_provider_tool_call_id": p_provider_tool_call_id,
                "p_content": p_content,
                "p_is_error": p_is_error
            }
        ).execute().data

    def get_tool_response_id(self, p_tool_call_id: str) -> str:
        """
        Gets the tool response id of a tool call if it exists.
        Parameters:
            p_tool_call_id: The tool call id.
        Returns:
            The tool response id.

        Returns:
            str
        """
        return self.get_supabase_client().rpc(
            "get_tool_response_id",
            {
                "p_tool_call_id": p_tool_call_id
            }
        ).execute().data

    def set_pretty_string(self, p_pretty_string: str) -> None:
        """
        Updates the pretty string of a tool call.
        Parameters:
            p_pretty_string: The pretty string to update.

        Returns:
            None
        """
        return self.get_supabase_client().rpc(
            "update_tool_call_pretty_string",
            {
                "p_tool_call_id": self.id,
                "p_pretty_string": p_pretty_string
            }
        ).execute().data
```